### PR TITLE
Remove 2.0 version from legal disclaimer

### DIFF
--- a/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedServerStartable.java
+++ b/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedServerStartable.java
@@ -76,7 +76,7 @@ public class SupportedServerStartable {
   private String legalDisclaimerProactiveSupportEnabled(long reportIntervalHours) {
     return "Please note that the support metrics collection feature (\"Metrics\") of Proactive Support is enabled.  " +
         "With Metrics enabled, this broker is configured to collect and report certain broker and " +
-        "cluster metadata (\"Metadata\") about your use of the Confluent Platform 2.0 (including " +
+        "cluster metadata (\"Metadata\") about your use of the Confluent Platform (including " +
         "without limitation, your remote internet protocol address) to Confluent, Inc. " +
         "(\"Confluent\") or its parent, subsidiaries, affiliates or service providers every " +
         reportIntervalHours +


### PR DESCRIPTION
Proposing removing 2.0 version from legal disclaimer because:
1) it's not applicable to 3.0 
2) it's easy to forget to update for new versions

@enothereska is this ok with you?