### PR TITLE
Remove dependency on metrics-fullcollector which is closed source.

### DIFF
--- a/support-metrics-client/pom.xml
+++ b/support-metrics-client/pom.xml
@@ -77,12 +77,6 @@
       <version>18.0</version>
       <scope>test</scope>
     </dependency>
-     <dependency>
-      <groupId>io.confluent.support</groupId>
-      <artifactId>support-metrics-fullcollector</artifactId>
-      <version>${confluent.support.metrics.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.confluent.support</groupId>
       <artifactId>support-metrics-common</artifactId>

--- a/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedServerStartable.java
+++ b/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedServerStartable.java
@@ -27,6 +27,7 @@ import kafka.server.KafkaServer;
 import kafka.utils.SystemTime$;
 import kafka.utils.VerifiableProperties;
 import scala.Option;
+import scala.collection.Seq;
 
 /**
  * Starts a Kafka broker plus an associated "support metrics" collection thread for this broker.
@@ -45,11 +46,10 @@ public class SupportedServerStartable {
   private Thread metricsThread = null;
 
   public SupportedServerStartable(Properties brokerConfiguration) {
-    KafkaMetricsReporter$.MODULE$.startReporters(new VerifiableProperties(brokerConfiguration));
+    Seq<KafkaMetricsReporter> reporters = KafkaMetricsReporter$.MODULE$.startReporters(new VerifiableProperties(brokerConfiguration));
     KafkaConfig serverConfig = KafkaConfig.fromProps(brokerConfiguration);
     Option<String> noThreadNamePrefix = Option.empty();
-    server = new KafkaServer(serverConfig, SystemTime$.MODULE$, noThreadNamePrefix,
-            scala.collection.JavaConversions.asScalaBuffer(Collections.<KafkaMetricsReporter>emptyList()));
+    server = new KafkaServer(serverConfig, SystemTime$.MODULE$, noThreadNamePrefix, reporters);
 
     if (SupportConfig.isProactiveSupportEnabled(brokerConfiguration)) {
       try {

--- a/support-metrics-client/src/test/java/io/confluent/support/metrics/SupportConfigTest.java
+++ b/support-metrics-client/src/test/java/io/confluent/support/metrics/SupportConfigTest.java
@@ -175,35 +175,6 @@ public class SupportConfigTest {
     assertThat(SupportConfig.getEndpointHTTPS(props)).isEqualTo("https://support-metrics.confluent.io/anon");
   }
 
-
-  @Test
-  public void testMergeAndValidatePropsCustomerEndpointMismatch() {
-    // Given
-    Properties overrideProps = new Properties();
-    overrideProps.setProperty(SupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG, "C1");
-
-    // When
-    Properties props = SupportConfig.mergeAndValidateWithDefaultProperties(overrideProps);
-
-    // Then
-    assertThat(SupportConfig.getEndpointHTTP(props)).isEqualTo("http://support-metrics.confluent.io/submit");
-    assertThat(SupportConfig.getEndpointHTTPS(props)).isEqualTo("https://support-metrics.confluent.io/submit");
-  }
-
-  @Test
-  public void testMergeAndValidatePropsConfluentTestEndpointMismatch() {
-    // Given
-    Properties overrideProps = new Properties();
-    overrideProps.setProperty(SupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG, "C0");
-
-    // When
-    Properties props = SupportConfig.mergeAndValidateWithDefaultProperties(overrideProps);
-
-    // Then
-    assertThat(SupportConfig.getEndpointHTTP(props)).isEqualTo("http://support-metrics.confluent.io/test");
-    assertThat(SupportConfig.getEndpointHTTPS(props)).isEqualTo("https://support-metrics.confluent.io/test");
-  }
-
   @Test
   public void testMergeAndValidatePropsDisableEndpoints() {
     // Given

--- a/support-metrics-client/src/test/java/io/confluent/support/metrics/collectors/CollectorFactoryTest.java
+++ b/support-metrics-client/src/test/java/io/confluent/support/metrics/collectors/CollectorFactoryTest.java
@@ -37,18 +37,4 @@ public class CollectorFactoryTest {
         // Then
         assertThat(type).isEqualTo(CollectorType.BASIC);
     }
-
-    @Test
-    public void testFullType() {
-        // Given
-        TimeUtils time = new TimeUtils();
-        CollectorFactory factory = new CollectorFactory(CollectorType.FULL, time, null, null, null);
-
-        // when
-        CollectorType type = factory.getType();
-
-        // Then
-        assertThat(type).isEqualTo(CollectorType.FULL);
-    }
-
 }


### PR DESCRIPTION
- Moved the tests for full-collector to the full collector repo.
- Fixed bug : Need to pass KafkaReporters to KafkaServers otherwise the reporters will not receive cluster id events.

@ewencp @enothereska Can you please review this PR ?