### PR TITLE
Don't register signal handlers if running on Windows

### DIFF
--- a/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedKafka.java
+++ b/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedKafka.java
@@ -18,7 +18,7 @@ package io.confluent.support.metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
+import java.util.ConcurrentHashMap;
 import java.util.Map;
 import java.util.Properties;
 import sun.misc.Signal;
@@ -76,10 +76,16 @@ public class SupportedKafka {
     jvmSignalHandlers.put(signalName, oldHandler);
   }
 
-  private static void registerLoggingSignalHandler(){
-    final Map<String, SignalHandler> jvmSignalHandlers = new HashMap<>();
-    registerSignalHandler("TERM", jvmSignalHandlers);
-    registerSignalHandler("INT", jvmSignalHandlers);
-    registerSignalHandler("HUP", jvmSignalHandlers);
+  private static boolean isWindows() {
+    return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows");
+  }
+
+  private static void registerLoggingSignalHandler() {
+    if (!isWindows()) {
+      final Map<String, SignalHandler> jvmSignalHandlers = new ConcurrentHashhMap<>();
+      registerSignalHandler("TERM", jvmSignalHandlers);
+      registerSignalHandler("INT", jvmSignalHandlers);
+      registerSignalHandler("HUP", jvmSignalHandlers);
+    }
   }
 }


### PR DESCRIPTION
The following happens on Windows for HUP (for Apache Kafka):

[2017-10-11 21:45:11,642] FATAL (kafka.Kafka$)
java.lang.IllegalArgumentException: Unknown signal: HUP
at sun.misc.Signal.(Unknown Source)
at kafka.Kafka$.registerHandler$1(Kafka.scala:67)
at kafka.Kafka$.registerLoggingSignalHandler(Kafka.scala:73)
at kafka.Kafka$.main(Kafka.scala:82)
at kafka.Kafka.main(Kafka.scala)

I thought it was safer not to register them at all since the additional
logging is a nice to have and we haven't tested it on Windows.

Also see https://github.com/apache/kafka/pull/4066.