### PR TITLE
Use Kafka's LoggingSignalHandler instead of sun.misc.SignalHandler

### DIFF
--- a/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedKafka.java
+++ b/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedKafka.java
@@ -16,18 +16,15 @@
 
 package io.confluent.support.metrics;
 
+import org.apache.kafka.common.utils.LoggingSignalHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sun.misc.Signal;
-import sun.misc.SignalHandler;
-
 import java.util.Locale;
-import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
 
 import kafka.Kafka;
+
 
 /**
  * Starts a "supported" Kafka broker and any associated threads.
@@ -48,8 +45,8 @@ public class SupportedKafka {
       final SupportedServerStartable supportedServerStartable =
           new SupportedServerStartable(serverProps);
 
-      // register signal handler to log termination due to SIGTERM, SIGHUP and SIGINT (control-c)
-      registerLoggingSignalHandler();
+      if (!isWindows() && !isIbmJdk())
+        new LoggingSignalHandler().register();
 
       // attach shutdown handler to catch terminating signals as well as normal termination
       Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -68,33 +65,12 @@ public class SupportedKafka {
     System.exit(ExitCodes.SUCCESS);
   }
 
-  private static void registerSignalHandler(
-      String signalName,
-      final Map<String, SignalHandler> jvmSignalHandlers
-  ) {
-    SignalHandler oldHandler = Signal.handle(new Signal(signalName), new SignalHandler() {
-      @Override
-      public void handle(Signal signal) {
-        log.info("Terminating process due to signal {}", signal);
-        SignalHandler oldHandler = jvmSignalHandlers.get(signal.getName());
-        if (oldHandler != null) {
-          oldHandler.handle(signal);
-        }
-      }
-    });
-    jvmSignalHandlers.put(signalName, oldHandler);
-  }
-
   private static boolean isWindows() {
     return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows");
   }
 
-  private static void registerLoggingSignalHandler() {
-    if (!isWindows()) {
-      final Map<String, SignalHandler> jvmSignalHandlers = new ConcurrentHashMap<>();
-      registerSignalHandler("TERM", jvmSignalHandlers);
-      registerSignalHandler("INT", jvmSignalHandlers);
-      registerSignalHandler("HUP", jvmSignalHandlers);
-    }
+  private static boolean isIbmJdk() {
+    return System.getProperty("java.vendor").contains("IBM");
   }
+
 }

--- a/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedKafka.java
+++ b/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedKafka.java
@@ -46,7 +46,12 @@ public class SupportedKafka {
           new SupportedServerStartable(serverProps);
 
       if (!isWindows() && !isIbmJdk())
-        new LoggingSignalHandler().register();
+        try {
+          new LoggingSignalHandler().register();
+        } catch (ReflectiveOperationException e) {
+          log.warn("Failed to register optional signal handler that logs a message when the process is " +
+                  "terminated via a signal. Reason for registration failure is: " + e);
+        }
 
       // attach shutdown handler to catch terminating signals as well as normal termination
       Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedKafka.java
+++ b/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedKafka.java
@@ -45,13 +45,15 @@ public class SupportedKafka {
       final SupportedServerStartable supportedServerStartable =
           new SupportedServerStartable(serverProps);
 
-      if (!isWindows() && !isIbmJdk())
+      if (!isWindows() && !isIbmJdk()) {
         try {
           new LoggingSignalHandler().register();
         } catch (ReflectiveOperationException e) {
-          log.warn("Failed to register optional signal handler that logs a message when the process is " +
-                  "terminated via a signal. Reason for registration failure is: " + e);
+          log.warn("Failed to register optional signal handler that logs a message when "
+                  + "the process is terminated via a signal. Reason for registration "
+                  + "failure is: " + e);
         }
+      }
 
       // attach shutdown handler to catch terminating signals as well as normal termination
       Runtime.getRuntime().addShutdownHook(new Thread() {


### PR DESCRIPTION
This fixes a compiler error when using javac --release 8.
LoggingSignalHandler uses reflection to avoid the compiler
error. See its documentation for a more detailed explanation
of why this is needed.