### PR TITLE
DOCS-379- Add anchor for doc reference

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. Confluent Proactive Support documentation master file
+.. _cp-proactive-support:
 
 Confluent Proactive Support
 ===========================


### PR DESCRIPTION
- required anchor for https://github.com/confluentinc/cp-docker-images/pull/483