### PR TITLE
Set version of maven-site and maven-project-info-reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
     <mockito.version>2.0.31-beta</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-assembly.version>2.6</maven-assembly.version>
+    <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+    <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
     <confluent.support.metrics.version>4.0.2-SNAPSHOT</confluent.support.metrics.version>
     <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
   </properties>
@@ -65,6 +67,23 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${maven-assembly.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${maven-site-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>${maven-project-info-reports-plugin.version}</version>
+          <configuration>
+            <!--
+            Disable dependency locations for latest maven-plugin-info-reports to eliminate blacklisting
+            warnings: "The repository url '...' is invalid - Repository '...' will be blacklisted."
+            -->
+            <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
More of this... 4.0.x branch does not use support-metrics-common as a parent POM, so the same changes that has been applied to support-metrics-common (in 4.0.x) to fix maven-site incompatibilities need to be applied here.