### PR TITLE
Remove extraneous version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
   </parent>
 
   <artifactId>support-metrics-client-parent</artifactId>
-  <version>4.1.1</version>
   <packaging>pom</packaging>
   <name>support-metrics-client-parent</name>
 


### PR DESCRIPTION
Currently, the `<version>4.1.1</version>` line causes the Jenkins build to fail during hotfix PR builds. This removes the line so as to avoid future build failures.